### PR TITLE
Added support for session result capture

### DIFF
--- a/src/main/java/com/intuit/maven/extensions/build/scanner/LifecycleProfiler.java
+++ b/src/main/java/com/intuit/maven/extensions/build/scanner/LifecycleProfiler.java
@@ -130,9 +130,15 @@ public class LifecycleProfiler extends AbstractEventSpy {
           }
         case SessionEnded:
           {
+            MavenSession session = executionEvent.getSession();
             sessionProfile.setEndTime(currentTimeMillis());
-            sessionProfile.setStatus(
-                sessionProfile.getProjectProfile(sessionProfile.getProject()).getStatus());
+
+            if (session.getResult().hasExceptions()) {
+              sessionProfile.setStatus(Status.FAILED);
+            } else {
+              sessionProfile.setStatus(Status.SUCCEEDED);
+            }
+
             dataStorage.close();
 
             LOGGER.info(

--- a/src/test/java/com/intuit/maven/extensions/build/scanner/TestExecutionEvent.java
+++ b/src/test/java/com/intuit/maven/extensions/build/scanner/TestExecutionEvent.java
@@ -3,6 +3,7 @@ package com.intuit.maven.extensions.build.scanner;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ProjectDependencyGraph;
@@ -14,7 +15,8 @@ class TestExecutionEvent implements ExecutionEvent {
   private final MavenProject project;
   private final MojoExecution mojoExecution;
   private final MavenSession mavenSession =
-      new MavenSession(null, null, new DefaultMavenExecutionRequest(), null);
+      new MavenSession(
+          null, null, new DefaultMavenExecutionRequest(), new DefaultMavenExecutionResult());
 
   private final List<MavenProject> projects;
 


### PR DESCRIPTION
The "Status" column for builds always showed "PENDING" or "SUCCESSFUL".

This change checks the final reactor result and sets the status to either "FAILED" or "SUCCEEDED" appropriately.