### PR TITLE
fixes #26 Dockerize node server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,29 @@ You should see the following line in the Maven console output:
 
     Open http://localhost:3000/?projectId=com.intuit:maven-build-scanner&sessionId=60acc519-ff2a-4c06-b79a-2aa23c47c861 to view your Maven build scanner results to view your Maven build scanner results
 
+## Alternative install via docker-compose and maven 
+
+1. Checkout the project from github
+2. Run `docker-compose up -d` to build the server and run mongo db and the server
+3. Run `mvn install` to build and install the maven plugin locally
+4. Configure the maven plugin using [Maven CoreExtensions](https://maven.apache.org/ref/3.6.3/maven-embedder/core-extensions.html) 
+   by adding add the following content to `.mvn/extensions.xml`:
+
+```xml
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>com.intuit</groupId>
+    <artifactId>maven-build-scanner</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </extension>
+</extensions>
+```
+Goto your project and run a maven build with profiling:
+
+To create a scan for another application, do the following:
+
+    env MAVEN_BUILD_SCANNER=1 mvn install
+
 # License
 Maven Build Scanner is released under the Apache 2.0 licenses. It uses [junit]( https://junit.org/junit4/) which is licensed under EPL 1.0.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.2'
+
+services:
+    build-scan-db:
+        image: mongo
+        ports:
+            - "27017:27017"
+        volumes:
+        -   "./db:/data/db"
+    server:
+        build:
+            context: ./server
+        depends_on:
+            - build-scan-db
+        ports:
+            - "3000:3000"
+        environment:
+            - MONGO_DB_HOST=build-scan-db
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
     build-scan-db:
-        image: mongo
+        image: mongo:4.4.5-bionic
         ports:
             - "27017:27017"
         volumes:
@@ -16,4 +16,3 @@ services:
             - "3000:3000"
         environment:
             - MONGO_DB_HOST=build-scan-db
-

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.eslintrc.js
+.dockerignore

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,7 @@
-FROM node:12.18.1
+FROM node:14.16.1-buster-slim
 WORKDIR /app
 ENV NODE_ENV=production
 COPY ["package.json", "package-lock.json*", "./"]
 RUN npm install --production
 COPY . .
 CMD [ "node", "start.js" ]
-

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:12.18.1
+WORKDIR /app
+ENV NODE_ENV=production
+COPY ["package.json", "package-lock.json*", "./"]
+RUN npm install --production
+COPY . .
+CMD [ "node", "start.js" ]
+

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,5 +2,5 @@ FROM node:14.16.1-buster-slim
 WORKDIR /app
 ENV NODE_ENV=production
 COPY . .
-RUN npm install --production
+RUN npm update && npm install --production
 CMD [ "node", "start.js" ]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:14.16.1-buster-slim
 WORKDIR /app
 ENV NODE_ENV=production
-COPY ["package.json", "package-lock.json*", "./"]
-RUN npm install --production
 COPY . .
+RUN npm install --production
 CMD [ "node", "start.js" ]

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -11,7 +11,11 @@ const ProjectSummary = mongoose.model("ProjectSummary");
 const SessionSummary = mongoose.model("SessionSummary");
 const SessionProfile = mongoose.model("SessionProfile");
 
-mongoose.connect("mongodb://localhost:27017/build_scans", { useNewUrlParser: true });
+const MONGO_DB_HOST = process.env.MONGO_DB_HOST || "localhost"
+const MONGO_DB_PORT = process.env.MONGO_DB_PORT || "27017"
+const MongoServerUrl = MONGO_DB_HOST + ":" + MONGO_DB_PORT;
+
+mongoose.connect("mongodb://"+MongoServerUrl+"/build_scans", { useNewUrlParser: true });
 mongoose.Promise = global.Promise;
 
 router.get("/", (req, res) => {


### PR DESCRIPTION
fixes #26 Added Dockerfile for node server to build and run it via docker-compose.

Please note unfortunately I couldn't check whether `setup.sh` still runs with my modifications because my nodejs version seems to be too old and I used the docker workaround to get the server running. So it worked with docker/docker-compose.

Unfortunately I'm no JavaScript developer and don't know much about coding conventions for JavaScript. Please review my changes to `index.js` and tell me whether I should change something or feel free to adapt the code yourself. 