### PR TITLE
fix getBranch NullPointerException when it can't find .git/HEAD

### DIFF
--- a/src/main/java/com/intuit/maven/extensions/build/scanner/LifecycleProfiler.java
+++ b/src/main/java/com/intuit/maven/extensions/build/scanner/LifecycleProfiler.java
@@ -223,7 +223,11 @@ public class LifecycleProfiler extends AbstractEventSpy {
       do {
         gitHead = new File(basedir, ".git/HEAD");
         basedir = basedir.getParentFile();
-      } while (!gitHead.exists());
+      } while (basedir != null && !gitHead.exists());
+
+      if (!gitHead.exists()) {
+          return "&lt;git not found&gt;";
+      }
 
       //noinspection OptionalGetWithoutIsPresent
       return Files.readAllLines(gitHead.toPath())


### PR DESCRIPTION
Check for null basedir and return not found text instead.